### PR TITLE
Fix bad notification configuration snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ Configuration wise:
 {
   "cffi/niri-taskbar": {
     // other settings
-    "notifications": true,
+    "notifications": {
+      "enabled": true,
+    },
   },
 }
 ```


### PR DESCRIPTION
With the erroneous config applied, niri-taskbar fails to start up.

Fixes #18 