### PR TITLE
Add support for gtk icon theme lookup

### DIFF
--- a/src/icon.rs
+++ b/src/icon.rs
@@ -68,7 +68,7 @@ fn lookup(id: &str) -> Option<PathBuf> {
 }
 
 fn lookup_icon(id: &str) -> Option<PathBuf> {
-    if let Some(path) = freedesktop_icons::lookup(id).with_size(512).find() {
+    if let Some(path) = freedesktop_icons::lookup(id).with_theme(&get_theme()).with_size(512).find() {
         return Some(path);
     }
 
@@ -81,6 +81,13 @@ fn lookup_icon(id: &str) -> Option<PathBuf> {
     }
 
     None
+}
+
+fn get_theme() -> String {
+    match freedesktop_icons::default_theme_gtk() {
+        None => "hicolor".to_string(),
+        Some(s) => s
+    }
 }
 
 static XDG_DATA_DIRS: LazyLock<Vec<PathBuf>> = LazyLock::new(|| {


### PR DESCRIPTION
Adds support for looking up the configured gtk icon theme. Using `freedesktop_icons::default_theme_gtk()`.
If none is found it defaults to the hicolor theme.

Some themes have whitespaces in the name these are not supported, this is something which needs to be looked into.
