### PR TITLE
Displaymodes extending PR #20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,9 +937,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "niri-ipc"
-version = "25.8.0"
+version = "25.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a336854faf3818ec2399152c994796e2e8d723867f9987f1e0cfeaae1dadaed1"
+checksum = "12bd9eb4e437f5282ce853cf66837658379cb537b4b6bae687da59246005329a"
 dependencies = [
  "serde",
  "serde_json",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "niri-taskbar"
-version = "0.3.0+niri.25.08"
+version = "0.3.0+niri.25.11"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1318,18 +1318,28 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1338,14 +1348,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "niri-taskbar"
 description = "Niri taskbar module for Waybar"
-version = "0.3.0+niri.25.08"
+version = "0.3.0+niri.25.11"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/LawnGnome/niri-taskbar"
@@ -19,7 +19,7 @@ freedesktop-icons = "0.4.0"
 futures = "0.3.31"
 itertools = "0.14.0"
 linicon = "2.3.0"
-niri-ipc = ">=25.8.0, <25.9.0"
+niri-ipc = "25.11"
 regex = "1.11.1"
 serde = { version = "1.0.218", features = ["derive"] }
 thiserror = "2.0.12"

--- a/README.md
+++ b/README.md
@@ -97,17 +97,20 @@ added.
 The easiest way to get the app ID for a window is to ask Niri with `niri msg
 windows`. Note that app IDs are case sensitive.
 
-### Multiple outputs
+### Display Modes
 
-By default, the taskbar will only show applications running on the same output
-as the taskbar itself. You can enable the `show_all_outputs` option to show all
-applications on all outputs:
+The taskbar supports multiples modes of displaying windows. 
+`display_mode` support 4 valuies:
+- `everything` (default) will display all the windows on all the outputs and workspaces on all taskbars
+- `by_outputs` will display the windows of the current output on the corresponding taskbar no matter the workspace
+- `by_workspace` will display only the windows of the currently activ workspace on the corresponding taskbar per output
+- `workspace buttons` will display the all windows of the corresponding output grouped with a button to the workspace they're on
 
 ```jsonc
 {
   "cffi/niri-taskbar": {
     // other settings
-    "show_all_outputs": true,
+    "displaymode": "by_workspace",
   },
 }
 ```
@@ -142,6 +145,10 @@ The taskbar uses [the same Gtk styling mechanism as Waybar][style]. The top
 level taskbar element is given the class `.niri-taskbar`, and contains `button`
 elements within it. The only CSS class that is applied by default is the
 `focused` class, which is added to the button for the currently focused window.
+
+If youre using `workspace-button` mode you can differentiate between window buttons and workspace buttons by refering to the css classes: `taskbar-button-workspace` and `taskbar-button-window`.
+Both of these buttons implement the `focused` class.
+
 
 The default styling assumes a dark background. It provides a basic hover
 effect, and highlights the focused window.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The taskbar supports multiples modes of displaying windows.
 - `everything` (default) will display all the windows on all the outputs and workspaces on all taskbars
 - `by_outputs` will display the windows of the current output on the corresponding taskbar no matter the workspace
 - `by_workspace` will display only the windows of the currently activ workspace on the corresponding taskbar per output
-- `workspace buttons` will display the all windows of the corresponding output grouped with a button to the workspace they're on
+- `workspace_buttons` will display the all windows of the corresponding output grouped with a button to the workspace they're on
 
 ```jsonc
 {
@@ -146,7 +146,7 @@ level taskbar element is given the class `.niri-taskbar`, and contains `button`
 elements within it. The only CSS class that is applied by default is the
 `focused` class, which is added to the button for the currently focused window.
 
-If youre using `workspace-button` mode you can differentiate between window buttons and workspace buttons by refering to the css classes: `taskbar-button-workspace` and `taskbar-button-window`.
+If youre using `workspace_buttons` mode you can differentiate between window buttons and workspace buttons by refering to the css classes: `taskbar-button-workspace` and `taskbar-button-window`.
 Both of these buttons implement the `focused` class.
 
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ level taskbar element is given the class `.niri-taskbar`, and contains `button`
 elements within it. The only CSS class that is applied by default is the
 `focused` class, which is added to the button for the currently focused window.
 
-If youre using `workspace_buttons` mode you can differentiate between window buttons and workspace buttons by refering to the css classes: `taskbar-button-workspace` and `taskbar-button-window`.
+If you're using `workspace_buttons` mode you can differentiate between window buttons and workspace buttons by referring to the css classes: `taskbar-button-workspace` and `taskbar-button-window`.
 Both of these buttons implement the `focused` class.
 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,8 +29,10 @@ pub struct Notifications {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum DisplayMode {
     Everything,
+    #[default]
     ByOutput,
     ByWorkspace,
     WorkspaceButtons,
@@ -47,11 +49,6 @@ impl Default for Notifications {
     }
 }
 
-impl Default for DisplayMode {
-    fn default() -> Self {
-         DisplayMode::Everything
-    }
-}
 
 fn default_true() -> bool {
     true

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,8 @@ pub struct Config {
     apps: HashMap<String, Vec<AppConfig>>,
     #[serde(default)]
     notifications: Notifications,
+    #[serde(default = "default_true")]
+    show_workspace_numbers: bool,
     #[serde(default)]
     show_all_outputs: bool,
 }
@@ -98,6 +100,11 @@ impl Config {
 
     pub fn show_all_outputs(&self) -> bool {
         self.show_all_outputs
+    }
+
+    /// Returns true if workspace numbers should be shown before each workspace's first icon.
+    pub fn show_workspace_numbers(&self) -> bool {
+        self.show_workspace_numbers
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,10 +11,8 @@ pub struct Config {
     apps: HashMap<String, Vec<AppConfig>>,
     #[serde(default)]
     notifications: Notifications,
-    #[serde(default = "default_true")]
-    show_workspace_numbers: bool,
     #[serde(default)]
-    show_all_outputs: bool,
+    display_mode: DisplayMode,
 }
 
 #[derive(Debug, Deserialize)]
@@ -29,6 +27,15 @@ pub struct Notifications {
     use_fuzzy_matching: bool,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DisplayMode {
+    Everything,
+    ByOutput,
+    ByWorkspace,
+    WorkspaceButtons,
+}
+
 impl Default for Notifications {
     fn default() -> Self {
         Self {
@@ -40,8 +47,20 @@ impl Default for Notifications {
     }
 }
 
+impl Default for DisplayMode {
+    fn default() -> Self {
+         DisplayMode::Everything
+    }
+}
+
 fn default_true() -> bool {
     true
+}
+
+pub struct DisplayVars {
+    pub filter_by_output: bool,
+    pub filter_by_workspace: bool,
+    pub  workspace_buttons: bool,
 }
 
 impl Config {
@@ -98,13 +117,13 @@ impl Config {
         self.notifications.use_fuzzy_matching
     }
 
-    pub fn show_all_outputs(&self) -> bool {
-        self.show_all_outputs
-    }
-
-    /// Returns true if workspace numbers should be shown before each workspace's first icon.
-    pub fn show_workspace_numbers(&self) -> bool {
-        self.show_workspace_numbers
+    pub fn display_vars(&self) -> DisplayVars {
+        match self.display_mode {
+            DisplayMode::Everything => DisplayVars { filter_by_output: false, filter_by_workspace: false, workspace_buttons: false },
+            DisplayMode::ByOutput => DisplayVars { filter_by_output:  true, filter_by_workspace: false, workspace_buttons: false },
+            DisplayMode::ByWorkspace => DisplayVars { filter_by_output: true, filter_by_workspace: true, workspace_buttons: false },
+            DisplayMode::WorkspaceButtons => DisplayVars { filter_by_output:  true, filter_by_workspace: false, workspace_buttons: true },
+        }
     }
 }
 

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -68,7 +68,7 @@ fn lookup(id: &str) -> Option<PathBuf> {
 }
 
 fn lookup_icon(id: &str) -> Option<PathBuf> {
-    if let Some(path) = freedesktop_icons::lookup(id).with_size(512).find() {
+    if let Some(path) = freedesktop_icons::lookup(id).with_theme(&get_theme()).with_size(512).find() {
         return Some(path);
     }
 
@@ -81,6 +81,13 @@ fn lookup_icon(id: &str) -> Option<PathBuf> {
     }
 
     None
+}
+
+fn get_theme() -> String {
+    match freedesktop_icons::default_theme_gtk() {
+        None => "hicolor".to_string(),
+        Some(s) => s
+    }
 }
 
 static XDG_DATA_DIRS: LazyLock<Vec<PathBuf>> = LazyLock::new(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,7 +402,8 @@ impl Instance {
             if self.state.config().show_workspace_numbers() {
                 if !self.workspace_buttons.contains_key(&ws_idx) {
                     let button = gtk::Button::with_label(&ws_idx.to_string());
-                    button.style_context().add_class("workspace-number"); //TODO: style
+                    button.style_context().add_class("taskbar-button-workspace");
+
 
                     let statec = self.state.clone();
                     button.connect_clicked(move |_| {
@@ -424,6 +425,7 @@ impl Instance {
                     // We add the widget here; container ordering will be rebuilt below so the
                     // precise position doesn't matter yet.
                     self.container.add(button.widget());
+                    button.widget().style_context().add_class("taskbar-button-window");
                     entry.insert(button)
                 }
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,6 +394,7 @@ impl Instance {
 
         // Filter windows by workspace only works if theyre also filtered by output
         // thats fine though because of DisplayVars enum. Stil be carefull
+        // This could be changed not necessary for now
         if self.state.config().display_vars().filter_by_workspace {
 
             let active_workspace_idx = match self.get_output(&filter).await {
@@ -487,6 +488,7 @@ impl Instance {
         }
 
         // Loop over Workspace Buttons and set focused only works with output Filter
+        // see: workspace filtering
         if let Some(output) = self.get_output(&filter).await {
 
             for button_t in &self.workspace_buttons {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,8 @@ use waybar_cffi::{
     gtk::{
         self, Orientation, gio,
         glib::MainContext,
-        traits::{BoxExt, ContainerExt, StyleContextExt, WidgetExt},
+    traits::{BoxExt, ContainerExt, StyleContextExt, WidgetExt},
+    prelude::Cast,
     },
     waybar_module,
 };
@@ -83,6 +84,9 @@ async fn init(info: &waybar_cffi::InitInfo, state: State) -> Result<(), Error> {
 
 struct Instance {
     buttons: BTreeMap<u64, Button>,
+    /// Map of workspace index -> label widget. Each workspace gets exactly one label
+    /// shown before the first app icon belonging to that workspace.
+    workspace_labels: BTreeMap<u64, gtk::Label>,
     container: gtk::Box,
     last_snapshot: Option<Snapshot>,
     state: State,
@@ -92,6 +96,7 @@ impl Instance {
     pub fn new(state: State, container: gtk::Box) -> Self {
         Self {
             buttons: Default::default(),
+            workspace_labels: Default::default(),
             container,
             last_snapshot: None,
             state,
@@ -364,19 +369,45 @@ impl Instance {
         // We need to track which, if any, windows are no longer present.
         let mut omitted = self.buttons.keys().copied().collect::<BTreeSet<_>>();
 
-        for window in windows.iter().filter(|window| {
-            filter
-                .lock()
-                .expect("output filter lock")
-                .should_show(window.output().unwrap_or_default())
-        }) {
+        // We'll track which workspaces we saw in this snapshot so we can remove labels for
+        // workspaces that no longer have any windows.
+        let mut seen_workspaces: BTreeSet<u64> = Default::default();
+
+        // Collect the windows we should show according to the output filter so we can both
+        // create/update widgets and then deterministically rebuild the container order.
+        let filtered_windows: Vec<_> = windows
+            .iter()
+            .filter(|window| {
+                filter
+                    .lock()
+                    .expect("output filter lock")
+                    .should_show(window.output().unwrap_or_default())
+            })
+            .collect();
+
+        for window in filtered_windows.iter().copied() {
+            seen_workspaces.insert(window.workspace_idx());
+
+            // If configured, ensure a label exists for this workspace even if the
+            // button already existed; this prevents labels from disappearing when
+            // windows move between workspaces.
+            let ws_idx = window.workspace_idx();
+            if self.state.config().show_workspace_numbers() {
+                if !self.workspace_labels.contains_key(&ws_idx) {
+                    let label = gtk::Label::new(Some(&ws_idx.to_string()));
+                    label.style_context().add_class("workspace-number");
+                    self.container.add(&label);
+                    self.workspace_labels.insert(ws_idx, label);
+                }
+            }
+
             let button = match self.buttons.entry(window.id) {
                 Entry::Occupied(entry) => entry.into_mut(),
                 Entry::Vacant(entry) => {
                     let button = Button::new(&self.state, window);
 
-                    // Implicitly adding the button widget to the box as we create it simplifies
-                    // reordering, since it means we can just do it as we go.
+                    // We add the widget here; container ordering will be rebuilt below so the
+                    // precise position doesn't matter yet.
                     self.container.add(button.widget());
                     entry.insert(button)
                 }
@@ -389,10 +420,8 @@ impl Instance {
             // Ensure we don't remove this button from the container.
             omitted.remove(&window.id);
 
-            // Since we get the windows in order in the snapshot, we can just
-            // push this to the back and then let other widgets push in front as
-            // we iterate.
-            self.container.reorder_child(button.widget(), -1);
+            // No per-button reordering here: we'll rebuild the container order below to
+            // ensure each workspace label appears immediately before its first app icon.
         }
 
         // Remove any windows that no longer exist.
@@ -400,6 +429,58 @@ impl Instance {
             if let Some(button) = self.buttons.remove(&id) {
                 self.container.remove(button.widget());
             }
+        }
+
+        // Remove any workspace labels for workspaces we didn't see.
+        if self.state.config().show_workspace_numbers() {
+            let existing_ws: Vec<u64> = self.workspace_labels.keys().copied().collect();
+            for ws in existing_ws.into_iter() {
+                if !seen_workspaces.contains(&ws) {
+                    if let Some(label) = self.workspace_labels.remove(&ws) {
+                        self.container.remove(&label);
+                    }
+                }
+            }
+        } else {
+            // If workspace numbers are disabled, ensure any existing labels are removed
+            // from the container and cleared.
+            if !self.workspace_labels.is_empty() {
+                // Consume the map so we can remove widgets from the container.
+                let labels = std::mem::take(&mut self.workspace_labels);
+                for (_ws, label) in labels.into_iter() {
+                    self.container.remove(&label);
+                }
+            }
+        }
+
+        // Rebuild the container order so that each workspace label appears immediately
+        // before the first app icon that belongs to that workspace.
+        let mut desired: Vec<gtk::Widget> = Vec::new();
+        let mut pushed_ws: BTreeSet<u64> = Default::default();
+
+        for window in filtered_windows.iter().copied() {
+            let ws_idx = window.workspace_idx();
+            if !pushed_ws.contains(&ws_idx) {
+                if self.state.config().show_workspace_numbers() {
+                    if let Some(label) = self.workspace_labels.get(&ws_idx) {
+                        desired.push(label.clone().upcast::<gtk::Widget>());
+                        pushed_ws.insert(ws_idx);
+                    }
+                }
+            }
+
+            if let Some(button) = self.buttons.get(&window.id) {
+                desired.push(button.widget().clone().upcast::<gtk::Widget>());
+            }
+        }
+
+        // Remove all existing children and re-add in the desired order.
+        for child in self.container.children() {
+            self.container.remove(&child);
+        }
+
+        for widget in desired.into_iter() {
+            self.container.add(&widget);
         }
 
         // Ensure everything is rendered.

--- a/src/niri/state.rs
+++ b/src/niri/state.rs
@@ -210,6 +210,7 @@ impl Niri {
             .map(|ww| Window {
                 window: ww.window.clone(),
                 output: ww.workspace.output.clone(),
+                workspace_idx: ww.workspace.idx as u64,
             })
             .collect()
     }
@@ -222,11 +223,17 @@ pub type Snapshot = Vec<Window>;
 pub struct Window {
     window: NiriWindow,
     output: Option<String>,
+    workspace_idx: u64,
 }
 
 impl Window {
     pub fn output(&self) -> Option<&str> {
         self.output.as_deref()
+    }
+
+    /// Returns the workspace index this window belongs to.
+    pub fn workspace_idx(&self) -> u64 {
+        self.workspace_idx
     }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -15,3 +15,15 @@ button.urgent {
 button:hover {
   background: rgba(255, 255, 255, 0.8);
 }
+
+/* Workspace number shown before the first icon of each workspace. */
+.workspace-number {
+  /* Small, unobtrusive pill with a little spacing */
+  padding: 0 6px;
+  margin: 0 6px 0 0;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.9);
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 6px;
+  min-height: 18px;
+}


### PR DESCRIPTION
I tried to combine multiple approaches to output and workspace filtering. There is a new `display_mode` config key which supports multiple modes: Adding labels/buttons for the corresponding workspace. From PR #20. Filtering by output or workspace. No filtering is default. 
I extended #20 and changed the labels to buttons which takes you to the corresponding workspace. Also they  support highlighting of the active workspace. Trying to combine a taskbar and workspace mode. There is also some new css classes.

This is supposed to be a rough starting point of unifying different approaches. For me it all works so far. But please test.
<img width="564" height="48" alt="Screenshot from 2025-10-30 19-53-20" src="https://github.com/user-attachments/assets/e56d4192-088c-4311-b5dc-77accbbcba8e" />
Example of `worskpace_buttons` mode

PR #22 is included.