### PR TITLE
fix: update niri-ipc to support niri v25.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,9 +937,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "niri-ipc"
-version = "25.8.0"
+version = "25.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a336854faf3818ec2399152c994796e2e8d723867f9987f1e0cfeaae1dadaed1"
+checksum = "12bd9eb4e437f5282ce853cf66837658379cb537b4b6bae687da59246005329a"
 dependencies = [
  "serde",
  "serde_json",
@@ -1318,18 +1318,28 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1338,14 +1348,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ freedesktop-icons = "0.4.0"
 futures = "0.3.31"
 itertools = "0.14.0"
 linicon = "2.3.0"
-niri-ipc = ">=25.8.0, <25.9.0"
+niri-ipc = ">=25.11.0, <25.12.0"
 regex = "1.11.1"
 serde = { version = "1.0.218", features = ["derive"] }
 thiserror = "2.0.12"


### PR DESCRIPTION
After updating to niri v25.11, niri-taskbar will halt:
```
2025-12-01T03:02:04.966836Z ERROR niri_taskbar::niri::window_stream: Niri IPC error reading from event stream e=unknown variant `WindowFocusTimestampChanged`, expected one of `WorkspacesChanged`, `WorkspaceUrgencyChanged`, `WorkspaceActivated`, `WorkspaceActiveWindowChanged`, `WindowsChanged`, `WindowOpenedOrChanged`, `WindowClosed`, `WindowFocusChanged`, `WindowUrgencyChanged`, `WindowLayoutsChanged`, `KeyboardLayoutsChanged`, `KeyboardLayoutSwitched`, `OverviewOpenedOrClosed`, `ConfigLoaded` at line 1 column 30
2025-12-01T03:02:04.967083Z ERROR niri_taskbar::niri::window_stream: Niri taskbar window stream error e=niri IPC: unknown variant `WindowFocusTimestampChanged`, expected one of `WorkspacesChanged`, `WorkspaceUrgencyChanged`, `WorkspaceActivated`, `WorkspaceActiveWindowChanged`, `WindowsChanged`, `WindowOpenedOrChanged`, `WindowClosed`, `WindowFocusChanged`, `WindowUrgencyChanged`, `WindowLayoutsChanged`, `KeyboardLayoutsChanged`, `KeyboardLayoutSwitched`, `OverviewOpenedOrClosed`, `ConfigLoaded` at line 1 column 30
^C[2025-12-01 11:02:19.046] [info] Quitting.
```
Simply update crate dependency niri-ipc from v25.8.0 to v25.11.0 can solve the issue.