### PR TITLE
fix: update niri-ipc to support niri v26.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,9 +953,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "niri-ipc"
-version = "25.11.0"
+version = "26.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bd9eb4e437f5282ce853cf66837658379cb537b4b6bae687da59246005329a"
+checksum = "6a4adbddf4037ce047854d36a60b5bf80a7990b8db2f0a0b9ede7534b0bae09a"
 dependencies = [
  "serde",
  "serde_json",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "niri-taskbar"
-version = "0.4.0+niri.25.11"
+version = "0.4.1+niri.26.4"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1370,15 +1370,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2162,6 +2162,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "niri-taskbar"
 description = "Niri taskbar module for Waybar"
-version = "0.4.0+niri.25.11"
+version = "0.4.1+niri.26.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/LawnGnome/niri-taskbar"
@@ -19,7 +19,7 @@ freedesktop-icons = "0.4.0"
 futures = "0.3.31"
 itertools = "0.14.0"
 linicon = "2.3.0"
-niri-ipc = ">=25.11.0, <25.12.0"
+niri-ipc = ">=26.4.0, <26.5.0"
 regex = "1.12.2"
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.17"


### PR DESCRIPTION
Bumps niri-ipc from 25.11.0 to 26.4.0 to handle the new CastsChanged IPC event introduced in niri v26.4. Without this update the taskbar crashes immediately because serde cannot deserialize the unknown variant.

Fix:#30