### PR TITLE
fix: gracefully skip unknown IPC events instead of crashing

### DIFF
--- a/src/niri/window_stream.rs
+++ b/src/niri/window_stream.rs
@@ -48,6 +48,9 @@ fn window_stream(tx: Sender<Snapshot>) -> Result<(), Error> {
                         .map_err(|_| Error::WindowStreamSend)?;
                 }
             }
+            Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+                tracing::warn!(%e, "Niri IPC: skipping unknown event");
+            }
             Err(e) => {
                 tracing::error!(%e, "Niri IPC error reading from event stream");
                 return Err(Error::NiriIpc(e));


### PR DESCRIPTION
 When niri introduces a new IPC event that niri-ipc doesn't know yet  (e.g. CastsChanged in niri v26.4), the event stream crashed with a  deserialization error and the taskbar stopped updating. 

Unknown events are now logged as a warning and skipped so the taskbar                                                                                            keeps running.                                                                                                                                                         

Fixes #30 